### PR TITLE
fix: Update marshmallow to use load_default

### DIFF
--- a/backend/application/marshmallowSchemas.py
+++ b/backend/application/marshmallowSchemas.py
@@ -68,7 +68,7 @@ class ServerSchema(BaseSchema):
 
     fleet = mafields.Nested(lambda: FleetSchema(exclude=('servers', )), many=False)
     # server_info = mafields.Nested(lambda: ServerQuerySchema, many=False)
-    server_info = fields.Nested(lambda: ServerQuerySchema, validate=existOrNone, missing=None)
+    server_info = fields.Nested(lambda: ServerQuerySchema, validate=existOrNone, load_default=None)
     watched_timestamp = fields.Integer(dump_only=True)
     monitored_timestamp = fields.Integer(dump_only=True)
     monitoring_picture_cached = fields.Integer(dump_only=True)


### PR DESCRIPTION
Replace `missing=None` with `load_default=None` in `ServerSchema` class in `marshmallowSchemas.py` to resolve TypeError caused by `marshmallow` 4.0.0 incompatibility. This ensures the Docker build completes successfully while maintaining compatibility with the latest `marshmallow` version.

fixes: #1 