### PR TITLE
build arguments to fix database migration

### DIFF
--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -2,6 +2,13 @@
 
 FROM python:3.12-slim
 
+# Define build arguments with default values
+ARG FLASK_APP=wsgi.py
+ARG FLASK_ENV=production
+
+# Set environment variables for the build
+ENV FLASK_APP=$FLASK_APP
+ENV FLASK_ENV=$FLASK_ENV
 
 WORKDIR /app
 COPY . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
         build: 
             context: backend
             dockerfile: docker/Dockerfile
+            args:
+                FLASK_APP: wsgi.py
+                FLASK_ENV: production
         working_dir: /app
         environment:
             - FLASK_APP=wsgi.py


### PR DESCRIPTION
This commit addresses an issue where `flask db upgrade` in `docker/install.sh` fails to create the `users` table due to missing `FLASK_APP` and `FLASK_ENV` environment variables during the Docker build. 

- Added `ARG` and `ENV` directives in `backend/docker/Dockerfile` to define `FLASK_APP=wsgi.py` and `FLASK_ENV=production` with defaults for `flask db upgrade`.
- Updated `docker-compose.yml` to explicitly pass `FLASK_APP` and `FLASK_ENV` as build arguments.

fixes: #3 