### PR TITLE
dynamic baseurl

### DIFF
--- a/web/src/api/apiConfig.js
+++ b/web/src/api/apiConfig.js
@@ -1,4 +1,4 @@
-const baseurl = typeof window !== 'undefined' ? window.location.origin || 'http://127.0.0.1:5001';
+const baseurl = window?.location?.origin || 'http://127.0.0.1:5001';
 // const baseurl = ""
 
 export {

--- a/web/src/api/apiConfig.js
+++ b/web/src/api/apiConfig.js
@@ -1,4 +1,4 @@
-const baseurl = "http://127.0.0.1:5001"
+const baseurl = typeof window !== 'undefined' ? window.location.origin || 'http://127.0.0.1:5001';
 // const baseurl = ""
 
 export {

--- a/web/src/components/ui/elements/GrafanaRenderedGraph.vue
+++ b/web/src/components/ui/elements/GrafanaRenderedGraph.vue
@@ -69,7 +69,7 @@ export default {
         },
         getImageURL: function() {
             const now = new Date().getTime()
-            const baseurl = typeof window !== 'undefined' ? window.location.origin || 'http://127.0.0.1:5001';
+            const baseurl = window?.location?.origin || 'http://127.0.0.1:5001';
             return `${baseUrl}/servers/monitoringImage/${this.server.id}/${this.panelId}/${this.getFromDate}?ts=${now}`
         },
         isImageLoaded: function() {

--- a/web/src/components/ui/elements/GrafanaRenderedGraph.vue
+++ b/web/src/components/ui/elements/GrafanaRenderedGraph.vue
@@ -69,7 +69,8 @@ export default {
         },
         getImageURL: function() {
             const now = new Date().getTime()
-            return `http://127.0.0.1:5001/servers/monitoringImage/${this.server.id}/${this.panelId}/${this.getFromDate}?ts=${now}`
+            const baseurl = typeof window !== 'undefined' ? window.location.origin || 'http://127.0.0.1:5001';
+            return `${baseUrl}/servers/monitoringImage/${this.server.id}/${this.panelId}/${this.getFromDate}?ts=${now}`
         },
         isImageLoaded: function() {
             return !this.loadingRequested && this.isLoaded
@@ -101,7 +102,6 @@ export default {
             }
         }
     }
-
 }
 </script>
 


### PR DESCRIPTION
Use window.location.origin for dynamic API base URL in frontend

This commit fixes hardcoded `http://127.0.0.1:5001` URLs in the frontend, which caused client browsers to attempt API calls to their local machine instead of the deployed server (e.g., `http://command.example.org:5001`). The changes update frontend to use `window.location.origin` for the API base URL, ensuring requests target the correct server in production.

Changes:
- Modified `web/src/api/apiConfig.js` to set `baseurl` using `typeof window !== 'undefined' ? window.location.origin : 'http://127.0.0.1:5001'`, ensuring compatibility with non-browser environments (e.g., during `vue-cli-service build`).
- Updated `web/src/components/ui/elements/GrafanaRenderedGraph.vue` to use the same dynamic base URL in the `getImageURL` computed property.
- Retained fallback to `http://127.0.0.1:5001` for local development and build-time safety.

These changes enable reliable API and monitoring image requests in hosted deployments without requiring environment variables or reverse proxies, while maintaining build compatibility.

fixes: #5 