### PR TITLE
integrate web build into backend Dockerfile

### DIFF
--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -1,10 +1,24 @@
 # syntax=docker/dockerfile:1
 
+FROM node:18-alpine as build
+
+WORKDIR /app
+
+COPY web/package*.json ./
+
+RUN npm install
+
+COPY web/ .
+
+RUN npm run build
+
 FROM python:3.12-slim
 
 
 WORKDIR /app
-COPY . /app
+COPY backend/ /app
 RUN bash docker/install.sh
+
+COPY --from=build /app/dist /app/application/dist
 
 # CMD ["flask", "run", "--port=5001", "--host=0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
     backend:
         build: 
-            context: backend
-            dockerfile: docker/Dockerfile
+            context: .
+            dockerfile: backend/docker/Dockerfile
         working_dir: /app
         environment:
             - FLASK_APP=wsgi.py
@@ -32,8 +32,8 @@ services:
 
     workers:
         build: 
-            context: backend
-            dockerfile: docker/Dockerfile
+            context: .
+            dockerfile: backend/docker/Dockerfile
         working_dir: /app
         environment:
             - FLASK_ENV=production


### PR DESCRIPTION
Collapsed `web/docker/Dockerfile` into `backend/docker/Dockerfile`
 - Updated backend/docker/Dockerfile to use multi-stage build with node:18-alpine to build web/ app and copy dist/ to backend/application/dist/
 - Modified docker-compose.yml to set build context to project root and use backend/docker/Dockerfile for backend and workers services

This simplifies deployment by automating the web app build and reducing manual steps. (possible fix for issue: #7 )